### PR TITLE
Got rid of types.* usage: deprecated in python 3

### DIFF
--- a/zplot/zplot.py
+++ b/zplot/zplot.py
@@ -2915,10 +2915,10 @@ class drawable:
             # [x,y] or, for e.g. a line, a list of points [[x1,y1],[x2,y2]].
             coord=['',''],
             ):
-        if type(coord) == types.ListType:
+        if type(coord) == list:
             # need to figure out: is this a simple list, or a list of lists?
             first = coord[0]
-            if type(first) == types.ListType:
+            if type(first) == list:
                 return self.translatecoord(coord)
             else:
                 return self.translatecoordsingle(coord)


### PR DESCRIPTION
Usage of types.* for basic types is no longer supported in python 3.x. As a result, the grid feature does not work.

Following simple change fixes the issue.